### PR TITLE
Banged examples first, description changed a little

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Check out the Codox API docs [here](http://michaeldrogalis.github.com/dire/).
 ```
 
 - Multiple pre-hooks evaluate in arbitrary order.
-- There's no with-post-hook. You have with-finally for that.
+- There's no `with-post-hook`. You have `with-finally` for that.
 
 ## Usage: Erlang Style with supervise
 


### PR DESCRIPTION
Dear Michael,

This is the change I hope you have in mind. I kept the supervise examples in below the banged versions. Tell my what you think (I tested all new ! examples!).

Additionally I did not put another issue in this pull request
(but I 'fixed' it in the banged example). To me the 
"Try/Catch/Finally Semantics" should have the `divider` function 
(instead of `add-one`) and catch the `ArithmeticException` instead 
of a `NullPointerException` (because the latter will never show up if you add). 
Do you agree?

Thanks again for all these nice ideas.

Best Regards from Berlin
Stefan Edlich
