### PR TITLE
Move transitive dependencies on midje, etc, to dev profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,12 +5,14 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :repositories {"stuart" "http://stuartsierra.com/maven2"}  
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/tools.nrepl "0.2.0-RC1"]
-                 [midje "1.4.0"]
-                 [com.stuartsierra/lazytest "1.2.3"]
                  [slingshot "0.10.3"]
-                 [robert/hooke "1.3.0"]
-                 [bultitude "0.1.7"]]
+                 [robert/hooke "1.3.0"]]
+  :profiles {:dev {:dependencies [[midje "1.4.0"]
+                                  [com.stuartsierra/lazytest "1.2.3"]
+                                  [bultitude "0.1.7"]
+                                  [org.clojure/tools.nrepl "0.2.0-RC1"]]}}
   :plugins [[lein-midje "2.0.3"]
-            [codox "0.6.4"]])
+            [codox "0.6.4"]]
+  :aliases {"midje-test" ["with-profile" "dev"
+                          "midje"]})
 


### PR DESCRIPTION
Move transitive dependencies, so that it's not necessary to pull these (and their conflicts) into every project which uses dire.

Added a "midje-test" alias so that tests can be run with "lein midje-test" using the dev profile. All facts pass.
