### PR TITLE
Changed (throw) to (throw+) in (default-error-handler)

### DIFF
--- a/src/dire/core.clj
+++ b/src/dire/core.clj
@@ -133,7 +133,7 @@
      (selector-matches? selector object) selector
      :else (recur (rest handlers) object))))
 
-(defn- default-error-handler [exception & _]
+(defn default-error-handler [exception & _]
   (throw+ exception))
 
 (defmulti apply-handler (fn [type & _] type))

--- a/test/dire/test/slingshot_handler_tests.clj
+++ b/test/dire/test/slingshot_handler_tests.clj
@@ -1,5 +1,4 @@
 (ns dire.test.slingshot-handler-tests
-  (:use [midje.util :only [testable-privates]])
   (:require [midje.sweet :refer :all]
             [dire.core :refer :all]
             [slingshot.slingshot :refer :all]))
@@ -76,8 +75,6 @@
 (fact :slingshot (test-function2 "BAD ARG") => (throws predicate-selector-exception?))
 
 ;; Make sure that the default-error-handler can propagate slingshot error maps
-(testable-privates dire.core default-error-handler)
-
 (fact :slingshot (default-error-handler {:error "error"}) => 
       (throws #(contains? (.getData %) :object)
               #(contains? (:object (.getData %)) :error)


### PR DESCRIPTION
I ran into the following stacktrace when some code I wrote triggered (dire.core/default-error-handler):

```
java.lang.ClassCastException: clojure.lang.PersistentArrayMap cannot be cast to java.lang.Throwable
    at dire.core$default_error_handler.doInvoke(core.clj:136)
    at clojure.lang.RestFn.applyTo(RestFn.java:139)
    at clojure.core$apply.invoke(core.clj:619)
    at dire.core$fn__8874.invoke(core.clj:159)
    at clojure.lang.MultiFn.invoke(MultiFn.java:236)
    at dire.core$supervised_meta.doInvoke(core.clj:184)
    at clojure.lang.RestFn.applyTo(RestFn.java:142)
    at clojure.core$apply.invoke(core.clj:619)
    at clojure.core$partial$fn__4190.doInvoke(core.clj:2396)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invoke(core.clj:619)
    at robert.hooke$compose_hooks$fn__8723.doInvoke(hooke.clj:40)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invoke(core.clj:617)
    at robert.hooke$run_hooks.invoke(hooke.clj:46)
    at robert.hooke$prepare_for_hooks$fn__8728$fn__8729.doInvoke(hooke.clj:54)
```

It looks like (default-error-handler) is calling (throw) which doesn't like the Slingshot error map that was getting passed to it. I changed (throw) to (throw+) and the above exception no longer gets raised.

I had a difficult time writing unit tests that triggered (default-error-handler) indirectly, so I resorted to Midje's (testable-privates) feature to call (default-error-handler) directly. My apologies if that's a problem. 
With the unit tests, I was able to verify that the above stacktrace was raised before the fix and is no longer present afterwards.
