### PR TITLE
Added support for multiple exceptions selector.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dire <a href="https://travis-ci.org/MichaelDrogalis/dire"><img src="https://api.travis-ci.org/MichaelDrogalis/dire.png" /></a>
 
-Decomplect error logic. Error handling, pre/post conditions and general hooks for Clojure functions. 
+Decomplect error logic. Error handling, pre/post conditions and general hooks for Clojure functions.
 
 Ships with two flavors:
 
@@ -52,6 +52,22 @@ Check out the Codox API docs [here](http://michaeldrogalis.github.com/dire/).
 (divider 10 0) ; => "Cannot divide by 0."
 ```
 
+#### Multiple Exception Classes
+
+Sometimes it is desirable to check for any one of a number of exceptions:
+
+```clojure
+(with-handler! #'divider
+  "Here's an optional docstring about the handler."
+  [java.lang.ArithmeticException,
+   java.lang.NullPointerException]
+  ;;; 'e' is the exception object, 'args' are the original arguments to the task.
+  (fn [e & args] (println "Cannot divide by 0 or operate on nil values.")))
+
+(divider 10 nil) ; => "Cannot divide by 0 or operate on nil values."
+(divider 10 0)   ; => "Cannot divide by 0 or operate on nil values."
+```
+
 ### Try/Catch/Finally Semantics
 ```clojure
 (ns mytask
@@ -87,7 +103,7 @@ Check out the Codox API docs [here](http://michaeldrogalis.github.com/dire/).
 (with-handler! #'f
   [:type :db-disconnection]
   (fn [e & args] "Safe and sound"))
-  
+
 (f) ;; => "Safe and sound"
 ```
 
@@ -100,7 +116,7 @@ Check out the Codox API docs [here](http://michaeldrogalis.github.com/dire/).
 (with-handler! #'f
   even?
   (fn [e & args] "Caught it"))
-  
+
 (f) ;; => "Caught it"
 ```
 
@@ -118,7 +134,7 @@ Check out the Codox API docs [here](http://michaeldrogalis.github.com/dire/).
   :not-two
   (fn [n & args]
     (not= n 2)))
-    
+
 (with-handler! #'add-one
   {:precondition :not-two}
   (fn [e & args] (apply str "Precondition failure for argument list: " (vector args))))
@@ -140,7 +156,7 @@ Check out the Codox API docs [here](http://michaeldrogalis.github.com/dire/).
   :not-two
   (fn [n & args]
     (not= n 2)))
-    
+
 (with-handler! #'add-one
   {:postcondition :not-two}
   (fn [e result] (str "Postcondition failed for result: " result)))
@@ -199,7 +215,7 @@ Check out the Codox API docs [here](http://michaeldrogalis.github.com/dire/).
   "A fake database query that sometimes fails"
   [query]
   (rand-nth [nil "valid-data"]))
-             
+
 (with-wrap-hook! #'fake-db-query
   "An optional docstring."
   (fn [result [query]]
@@ -350,7 +366,7 @@ Check out the Codox API docs [here](http://michaeldrogalis.github.com/dire/).
   "A fake database query that sometimes fails"
   [query]
   (rand-nth [nil "valid-data"]))
-             
+
 (defn check-result
   [result [query]]
   (if (not-empty result)

--- a/src/dire/core.clj
+++ b/src/dire/core.clj
@@ -164,7 +164,12 @@
    :class-name
 
    (and (vector? selector)
-        (even? (count selector)))
+        (every? class? selector))
+   :class-names
+
+   (and (vector? selector)
+        (even? (count selector))
+        (every? keyword? (take-nth 2 selector)))
    :key-values
 
    (fn? selector)
@@ -176,6 +181,9 @@
 
 (defmethod selector-matches? :class-name [selector object]
   (instance? selector object))
+
+(defmethod selector-matches? :class-names [selectors object]
+  (some #(instance? % object) selectors))
 
 (defmethod selector-matches? :key-values [selector object]
   (let [key-val-tests (for [[key val] (partition 2 selector)]

--- a/test/dire/test/multiple_exception_selectors.clj
+++ b/test/dire/test/multiple_exception_selectors.clj
@@ -1,0 +1,17 @@
+(ns dire.test.multiple-exception-selectors
+  (:require [midje.sweet :refer :all]
+            [dire.core :refer :all]))
+
+(defn divider [a b]
+  (/ a b))
+
+(with-handler #'divider
+  "Catches divide by 0 and null exception errors."
+  [java.lang.ArithmeticException
+   java.lang.NullPointerException]
+  (fn [e & args] :dbz-and-npe-handler))
+
+(fact (supervise #'divider 10 2) => 5)
+(fact (supervise #'divider 10 0) => :dbz-and-npe-handler)
+(fact (supervise #'divider 10 nil) => :dbz-and-npe-handler)
+

--- a/test/dire/test/multiple_mutation_exception_selectors.clj
+++ b/test/dire/test/multiple_mutation_exception_selectors.clj
@@ -1,0 +1,16 @@
+(ns dire.test.multiple-mutation-exception-selectors
+  (:require [midje.sweet :refer :all]
+            [dire.core :refer :all]))
+
+(defn divider [a b]
+  (/ a b))
+
+(with-handler! #'divider
+  "Catches divide by 0 and null exception errors."
+  [java.lang.ArithmeticException,
+   java.lang.NullPointerException]
+  (fn [e & args] :dbz-and-npe-handler))
+
+(fact (divider 10 2) => 5)
+(fact (divider 10 0) => :dbz-and-npe-handler)
+(fact (divider 10 nil) => :dbz-and-npe-handler)


### PR DESCRIPTION
Addresses issue/request of ticket #33.

Adding support for this feature required a change to the private function `selector-type`: the check for `:key-values` was originally `vector?` and ensuring there were an even number of elements. This would obviously conflict with an even number of exceptions. So I added a third requirement: every other element must be a keyword for it to be a `:key-values`. This then left room for a new selector type: `:class-names` which checks if every element of the vector is a class.

To pair with that, I added a new `selector-matches?` method that checks that the given object is an instance of at least one of the elements in the vector of exception classes.
